### PR TITLE
Feat/archive redesign

### DIFF
--- a/src/_includes/components/site-header.webc
+++ b/src/_includes/components/site-header.webc
@@ -68,6 +68,27 @@
     transition: background-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
   }
 
+  .nav-links a.nav-link-stacked {
+    align-items: flex-end;
+    display: inline-flex;
+    flex-direction: column;
+    gap: 2px;
+    line-height: 1.1;
+  }
+
+  .nav-link-kicker {
+    font-size: 9px;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    line-height: 1;
+    opacity: 0.9;
+    text-transform: uppercase;
+  }
+
+  .nav-link-main {
+    line-height: 1.2;
+  }
+
   .nav-links a:hover {
     background: rgba(247, 203, 156, 0.55);
     box-shadow: -6px 6px 0 rgb(0 0 0 / 18%);
@@ -110,10 +131,15 @@
   <div class="new-header-content">
     <a href="/" class="site-title">Creative Computing Cookbook</a>
     <ul class="nav-links">
-      <li><a href="/all-recipes/">All Recipes</a></li>
       <li><a href="/all-recipes/#builds">Builds</a></li>
       <li><a href="/all-recipes/#foundations">Foundations</a></li>
-      <li><a href="/about">About</a></li>
+      <li>
+        <a href="/learning-activities/" class="nav-link-stacked">
+          <span class="nav-link-kicker">For Instructors ✨</span>
+          <span class="nav-link-main">Learning Activities</span>
+        </a>
+      </li>
+      <li><a href="/about/">About</a></li>
     </ul>
   </div>
 </header>

--- a/src/_includes/components/site-header.webc
+++ b/src/_includes/components/site-header.webc
@@ -68,27 +68,6 @@
     transition: background-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
   }
 
-  .nav-links a.nav-link-stacked {
-    align-items: flex-end;
-    display: inline-flex;
-    flex-direction: column;
-    gap: 2px;
-    line-height: 1.1;
-  }
-
-  .nav-link-kicker {
-    font-size: 9px;
-    font-weight: 700;
-    letter-spacing: 0.04em;
-    line-height: 1;
-    opacity: 0.9;
-    text-transform: uppercase;
-  }
-
-  .nav-link-main {
-    line-height: 1.2;
-  }
-
   .nav-links a:hover {
     background: rgba(247, 203, 156, 0.55);
     box-shadow: -6px 6px 0 rgb(0 0 0 / 18%);
@@ -133,12 +112,7 @@
     <ul class="nav-links">
       <li><a href="/all-recipes/#builds">Builds</a></li>
       <li><a href="/all-recipes/#foundations">Foundations</a></li>
-      <li>
-        <a href="/learning-activities/" class="nav-link-stacked">
-          <span class="nav-link-kicker">For Instructors ✨</span>
-          <span class="nav-link-main">Learning Activities</span>
-        </a>
-      </li>
+      <li><a href="/learning-activities/">Learning Activities</a></li>
       <li><a href="/about/">About</a></li>
     </ul>
   </div>

--- a/src/_includes/layouts/all-recipes.webc
+++ b/src/_includes/layouts/all-recipes.webc
@@ -155,7 +155,7 @@ function item(settings) {
 <main id="main-content" tabindex="-1">
 <div>
   <div class="home relative overflow-hidden">
-    <div class="m-auto prose md:prose-base prose-sm text-white size-fit py-[15%] px-4">
+    <div class="m-auto prose md:prose-base prose-sm size-fit py-[5%] px-4">
       <template @raw="content" webc:nokeep></template>
     </div>
     <div class="size-[100%]">
@@ -221,7 +221,7 @@ function item(settings) {
             <div class="archive-dropdown" x-show="openDropdown === cat" x-on:click.outside="openDropdown = null" x-transition>
               <template x-for="tag in setup[cat]" :key="tag">
                 <label class="archive-tag-row" x-on:click="$store.store.toggleTag(tag)">
-                  <span class="archive-tag-label" x-text="tag"></span>
+                  <span class="archive-tag-label" x-text="tag + ' (' + $store.store.countPagesForTag(tag) + ')' "></span>
                   <span class="archive-tag-radio" x-bind:class="isTagActive(tag) ? 'archive-tag-radio-on' : 'archive-tag-radio-off'"></span>
                 </label>
               </template>

--- a/src/_includes/layouts/all-recipes.webc
+++ b/src/_includes/layouts/all-recipes.webc
@@ -13,6 +13,14 @@ handleHashChange = () => {
     case '#foundations':
       Alpine.store("store").setCategory("Foundations");
       break;
+    case '#trinket':
+      Alpine.store("store").setCategory("Builds");
+      Alpine.store("store").setHardware("Trinket");
+      break;
+    case '#arduino':
+      Alpine.store("store").setCategory("Builds");
+      Alpine.store("store").setHardware("Arduino");
+      break;
   }
   window.location.hash = '';
 }

--- a/src/_includes/layouts/home.webc
+++ b/src/_includes/layouts/home.webc
@@ -52,7 +52,7 @@ layout: 'layouts/base.webc'
           <div class="home-hw-inner">
             <div class="home-hw-header">
               <span class="home-hw-label">TRINKET</span>
-              <a href="/all-recipes/#builds" class="home-hw-arrow" aria-label="Explore Trinket builds">
+              <a href="/all-recipes/#trinket" class="home-hw-arrow" aria-label="Explore Trinket builds">
                 <svg width="10" height="12" viewBox="0 0 10 14" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
                   <polygon points="0,0 10,7 0,14" fill="#1E1E1E"/>
                 </svg>
@@ -69,7 +69,7 @@ layout: 'layouts/base.webc'
           <div class="home-hw-inner">
             <div class="home-hw-header">
               <span class="home-hw-label">ARDUINO</span>
-              <a href="/all-recipes/#builds" class="home-hw-arrow" aria-label="Explore Arduino builds">
+              <a href="/all-recipes/#arduino" class="home-hw-arrow" aria-label="Explore Arduino builds">
                 <svg width="10" height="12" viewBox="0 0 10 14" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
                   <polygon points="0,0 10,7 0,14" fill="#1E1E1E"/>
                 </svg>

--- a/src/all-recipes.md
+++ b/src/all-recipes.md
@@ -7,4 +7,6 @@ meta:
 
 # Creative Computing Cookbook
 
-Our cookbook is designed to help both students and teachers explore and achieve their learning goals in a structured and engaging way. It offers a variety of resources, guides, and activities to support your educational journey.
+**Builds** are creative projects made by students or instructors integrating technology into dance, performance, visual art and poetry. Builds vary in complexity, but most would take several hours to replicate. We hope you'll use them as inspiration for your own creative goals.
+
+**Foundations** provide information about individual electronic components. In each post you'll find details about how to plug elements in, example code, and opportunities to practice your code.

--- a/src/learning-activities.md
+++ b/src/learning-activities.md
@@ -1,0 +1,12 @@
+---
+layout: 'layouts/info.webc'
+title: 'Learning Activities'
+meta:
+  desc:
+    'Learning activities page.'
+eleventyExcludeFromCollections: true
+---
+
+# Learning Activities
+
+This is a placeholder Learning Activities page.

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -747,8 +747,10 @@ code .highlight-line::before {
 .pagination a {
   border-radius: 5px;
   color: black;
+  cursor: pointer;
   padding: 8px 12px;
   text-decoration: none;
+  user-select: none;
 }
 
 .pagination a.active {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -45,11 +45,16 @@ body {
 }
 
 .home {
-  background: #2a005faa;
+  background: linear-gradient(180deg, #fff3dc 0%, #f4c2ff 56%, #fffaef 100%);
 }
 
 .home h1 {
-  color: var(--color-white);
+  color: #4b2378;
+}
+
+.home .prose,
+.home .prose p {
+  color: #4b2378;
 }
 
 /* As we cannot replace the numbers with variables or calls to element
@@ -790,14 +795,14 @@ code .highlight-line::before {
   align-items: center;
   display: flex;
   flex-wrap: wrap;
-  gap: 6px;
+  gap: 12px;
 }
 
 /* Hardware buttons */
 .archive-hw-group {
   align-items: center;
   display: flex;
-  gap: 6px;
+  gap: 12px;
 }
 
 .archive-hw-btn {
@@ -833,7 +838,7 @@ code .highlight-line::before {
   border-radius: 12px;
   flex-shrink: 0;
   height: 44px;
-  margin: 0 4px;
+  margin: 0 8px;
   width: 4px;
 }
 
@@ -842,7 +847,7 @@ code .highlight-line::before {
   align-items: center;
   display: flex;
   flex-wrap: wrap;
-  gap: 6px;
+  gap: 12px;
 }
 
 .archive-cat-wrap {


### PR DESCRIPTION
# What does this update/change/Pull-Request do?

This PR refreshes the homepage/archive navigation and archive-page UX/content.

It includes:
- Added hardware-specific deep links from Home to All Recipes filters (Trinket/Arduino).
- Improved archive-page hero presentation:
  - reduced hero height,
  - updated copy for Builds and Foundations,
  - adjusted hero colors to a softer gradient transition (navbar color -> light purple -> archive background),
  - aligned hero text color for readability.
- Improved archive filter usability:
  - increased spacing between filter controls so active shadows don’t crowd nearby buttons,
  - added per-tag item counts in filter dropdown labels (shown as `Tag Name (count)`).
- Fixed pagination affordance by forcing pointer behavior on hover.
- Updated global navbar:
  - removed “All Recipes” nav item,
  - fixed About route (`/about/`) to avoid 404,
  - added new “Learning Activities” nav entry 
- Added a placeholder Learning Activities page.

## What issues does this update/change/Pull-Request address?

No linked issue.

This PR addresses:
- Archive navigation/filter friction (hardware links not applying expected filter context).
- Visual/interaction polish concerns on archive filter controls and hero transition.
- Missing destination page for the new Learning Activities nav route.

# Did you...

- [x] Test your updates/changes locally?
- [x] Document your updates/changes sufficiently, in the pull request, commit descriptions, or code comments?

## Any remaining work to be done?

- Replace the Learning Activities placeholder content with finalized instructional content.